### PR TITLE
HW2 Basic SQL Queries

### DIFF
--- a/hw2-q1.sql
+++ b/hw2-q1.sql
@@ -1,0 +1,16 @@
+--q1
+SELECT DISTINCT flight_num AS flight_num
+FROM FLIGHTS AS F, CARRIERS AS C, WEEKDAYS AS W
+WHERE F.carrier_id = C.cid
+AND W.did = F.day_of_week_id
+AND F.origin_city = 'Seattle WA' 
+AND F.dest_city = 'Boston MA' 
+AND C.name = 'Alaska Airlines Inc.'
+AND W.day_of_week = 'Monday';
+
+/*
+flight_num
+12
+24
+734
+*/

--- a/hw2-q2.sql
+++ b/hw2-q2.sql
@@ -1,0 +1,46 @@
+--q2
+SELECT C.name AS name, 
+F1.flight_num AS f1_flight_num,
+F1.origin_city AS f1_origin_city,
+F1.dest_city AS f1_dest_city,
+F1.actual_time AS f1_actual_time,
+F2.flight_num AS f2_flight_num,
+F2.origin_city AS f2_origin_city,
+F2.dest_city AS f2_dest_city,
+F2.actual_time AS f2_actual_time,
+F1.actual_time + F2.actual_time AS actual_time
+FROM FLIGHTS AS F1, FLIGHTS AS F2, CARRIERS AS C, MONTHS AS M
+WHERE M.mid = 7
+AND F1.month_id = M.mid
+AND F2.month_id = M.mid
+AND F1.day_of_month = 15
+AND F2.day_of_month = 15
+AND F1.dest_city = F2.origin_city
+AND F1.origin_city = 'Seattle WA'
+AND F2.dest_city = 'Boston MA'
+AND F1.carrier_id = C.cid
+AND F2.carrier_id = C.cid
+AND F1.carrier_id = F2.carrier_id
+AND (F1.actual_time + F2.actual_time) < 420;
+
+/*
+total 1472rows like this:
+name	f1_flight_num	f1_origin_city	f1_dest_city	f1_actual_time	f2_flight_num	f2_origin_city	f2_dest_city	f2_actual_time	actual_time
+American Airlines Inc.	198	Seattle WA	New York NY	339	84	New York NY	Boston MA	74	413
+American Airlines Inc.	198	Seattle WA	New York NY	339	199	New York NY	Boston MA	80	419
+American Airlines Inc.	198	Seattle WA	New York NY	339	1443	New York NY	Boston MA	80	419
+American Airlines Inc.	198	Seattle WA	New York NY	339	2118	New York NY	Boston MA	0	339
+American Airlines Inc.	198	Seattle WA	New York NY	339	2121	New York NY	Boston MA	74	413
+American Airlines Inc.	198	Seattle WA	New York NY	339	2122	New York NY	Boston MA	65	404
+American Airlines Inc.	198	Seattle WA	New York NY	339	2126	New York NY	Boston MA	60	399
+American Airlines Inc.	198	Seattle WA	New York NY	339	2131	New York NY	Boston MA	70	409
+American Airlines Inc.	198	Seattle WA	New York NY	339	2136	New York NY	Boston MA	63	402
+American Airlines Inc.	198	Seattle WA	New York NY	339	2141	New York NY	Boston MA	57	396
+American Airlines Inc.	198	Seattle WA	New York NY	339	2146	New York NY	Boston MA	60	399
+American Airlines Inc.	198	Seattle WA	New York NY	339	2152	New York NY	Boston MA	69	408
+American Airlines Inc.	198	Seattle WA	New York NY	339	2156	New York NY	Boston MA	79	418
+American Airlines Inc.	198	Seattle WA	New York NY	339	2158	New York NY	Boston MA	67	406
+American Airlines Inc.	198	Seattle WA	New York NY	339	2162	New York NY	Boston MA	0	339
+American Airlines Inc.	198	Seattle WA	New York NY	339	2168	New York NY	Boston MA	54	393
+American Airlines Inc.	198	Seattle WA	New York NY	339	2172	New York NY	Boston MA	80	419
+*/

--- a/hw2-q3.sql
+++ b/hw2-q3.sql
@@ -1,0 +1,11 @@
+--q3
+SELECT W.day_of_week AS day_of_week, AVG(F.arrival_delay) AS delay
+FROM WEEKDAYS AS W, FLIGHTS AS F
+WHERE F.day_of_week_id = W.did
+GROUP BY W.did
+ORDER BY AVG(F.arrival_delay) DESC
+LIMIT 1;
+/* 
+day_of_week	delay
+Friday	14.4725010477787
+*/

--- a/hw2-q4.sql
+++ b/hw2-q4.sql
@@ -1,0 +1,22 @@
+--q4
+SELECT DISTINCT C.name AS name
+FROM FLIGHTS AS F, CARRIERS AS C, MONTHS AS M
+WHERE F.carrier_id = C.cid
+AND F.month_id = M.mid
+GROUP BY M.mid, F.day_of_month, C.name
+HAVING COUNT(C.name) > 1000;
+/*
+name
+American Airlines Inc.
+Comair Inc.
+Delta Air Lines Inc.
+Envoy Air
+ExpressJet Airlines Inc.
+ExpressJet Airlines Inc. (1)
+JetBlue Airways
+Northwest Airlines Inc.
+SkyWest Airlines Inc.
+Southwest Airlines Co.
+US Airways Inc.
+United Air Lines Inc.
+*/

--- a/hw2-q5.sql
+++ b/hw2-q5.sql
@@ -1,0 +1,17 @@
+--q5
+SELECT C.name AS name, AVG(F.canceled)*100 AS percentage
+FROM FLIGHTS AS F, CARRIERS AS C
+WHERE F.carrier_id = C.cid
+AND F.origin_city = 'Seattle WA'
+GROUP BY C.name
+HAVING AVG(F.canceled) > 0.005
+ORDER BY AVG(F.canceled);
+/*
+name	percentage
+SkyWest Airlines Inc.	0.728291316526611
+Frontier Airlines Inc.	0.840336134453782
+United Air Lines Inc.	0.983767830791933
+JetBlue Airways	1.00250626566416
+Northwest Airlines Inc.	1.4336917562724
+ExpressJet Airlines Inc.	3.2258064516129
+*/

--- a/hw2-q6.sql
+++ b/hw2-q6.sql
@@ -1,0 +1,12 @@
+--q6
+SELECT DISTINCT C.name AS carrier, MAX(F.price) AS max_price
+FROM FLIGHTS AS F, CARRIERS AS C
+WHERE F.carrier_id = C.cid
+AND ((F.origin_city = 'Seattle WA' AND F.dest_city = 'New York NY') OR (F.origin_city = 'New York NY' AND F.dest_city = 'Seattle WA'))
+GROUP BY C.name;
+/*
+carrier	max_price
+American Airlines Inc.	991
+Delta Air Lines Inc.	999
+JetBlue Airways	996
+*/

--- a/hw2-q7.sql
+++ b/hw2-q7.sql
@@ -1,0 +1,12 @@
+--q7
+SELECT SUM(F.capacity) AS capacity
+FROM FLIGHTS AS F, MONTHS AS M
+WHERE F.month_id = M.mid
+AND M.mid = 7
+AND F.day_of_month = 10
+AND (F.origin_city = 'Seattle WA' and F.dest_city = 'San Francisco CA' 
+OR F.origin_city = 'San Francisco CA' and F.dest_city = 'Seattle WA');
+/*
+capacity
+680
+*/

--- a/hw2-q8.sql
+++ b/hw2-q8.sql
@@ -1,0 +1,30 @@
+--q8
+SELECT C.name AS name, SUM(F.departure_delay) AS delay
+FROM FLIGHTS AS F, CARRIERS AS C
+WHERE F.carrier_id = C.cid
+GROUP BY C.name;
+/*
+name	delay
+ATA Airlines d/b/a ATA	38676
+AirTran Airways Corporation	473993
+Alaska Airlines Inc.	285111
+America West Airlines Inc. (Merged with US Airways 9/05. Stopped reporting 10/07.)	173255
+American Airlines Inc.	1849386
+Comair Inc.	282042
+Continental Air Lines Inc.	414226
+Delta Air Lines Inc.	1601314
+Envoy Air	771679
+ExpressJet Airlines Inc.	934691
+ExpressJet Airlines Inc. (1)	483171
+Frontier Airlines Inc.	165126
+Hawaiian Airlines Inc.	386
+Independence Air	201418
+JetBlue Airways	435562
+Northwest Airlines Inc.	531356
+SkyWest Airlines Inc.	682158
+Southwest Airlines Co.	3056656
+Spirit Air Lines	167894
+US Airways Inc.	577268
+United Air Lines Inc.	1483777
+Virgin America	52597
+*/


### PR DESCRIPTION
(10 points) List the distinct flight numbers of all flights from Seattle to Boston by Alaska Airlines Inc. on Mondays. Also notice that, in the database, the city names include the state. So Seattle appears as Seattle WA. Please use the flight_num column instead of fid. Name the output column flight_num.
 [Hint: Output relation cardinality: 3 rows]


(10 points) Find all itineraries from Seattle to Boston on July 15th. Search only for itineraries that have one stop (i.e., flight 1: Seattle -> [somewhere], flight2: [somewhere] -> Boston). Both flights must depart on the same day (same day here means the date of flight) and must be with the same carrier. It's fine if the landing date is different from the departing date (i.e., in the case of an overnight flight). You don't need to check whether the first flight overlaps with the second one since the departing and arriving time of the flights are not provided.

 The total flight time (actual_time) of the entire itinerary should be fewer than 7 hours (but notice that actual_time is in minutes). For each itinerary, the query should return the name of the carrier, the first flight number, the origin and destination of that first flight, the flight time, the second flight number, the origin and destination of the second flight, the second flight time, and finally the total flight time. Only count flight times here; do not include any layover time.

 Name the output columns name (as in the name of the carrier), f1_flight_num, f1_origin_city, f1_dest_city, f1_actual_time, f2_flight_num, f2_origin_city, f2_dest_city, f2_actual_time, and actual_time as the total flight time. List the output columns in this order. [Output relation cardinality: 1472 rows]


(10 points) Find the day of the week with the longest average arrival delay. Return the name of the day and the average delay.
 Name the output columns day_of_week and delay, in that order. (Hint: consider using LIMIT. Look up what it does!)
 [Output relation cardinality: 1 row]


(10 points) Find the names of all airlines that ever flew more than 1000 flights in one day (i.e., a specific day/month, but not any 24-hour period). Return only the names of the airlines. Do not return any duplicates (i.e., airlines with the exact same name).
 Name the output column name.
 [Output relation cardinality: 12 rows]


(10 points) Find all airlines that had more than 0.5% (= 0.005) of their flights out of Seattle canceled. Return the name of the airline and the percentage of canceled flights out of Seattle. Percentages should be outputted in percent format (3.5% as 3.5 not 0.035). Order the results by the percentage of canceled flights in ascending order.
 Name the output columns name and percentage, in that order.
 [Output relation cardinality: 6 rows]


(10 points) Find the maximum price of tickets between Seattle and New York, NY (i.e. Seattle to NY or NY to Seattle). Show the maximum price for each airline separately.
 Name the output columns carrier and max_price, in that order.
 [Output relation cardinality: 3 rows]


(10 points) Find the total capacity of all direct flights that fly between Seattle and San Francisco, CA on July 10th (i.e. Seattle to SF or SF to Seattle).
 Name the output column capacity.
 [Output relation cardinality: 1 row]


(10 points) Compute the total departure delay of each airline across all flights. Some departure delays may be negative (indicating an early departure); they should reduce the total, so you don't need to handle them specially. Name the output columns name and delay, in that order. [Output relation cardinality: 22 rows]